### PR TITLE
fix: readme.md debian installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Install from the AUR (`yay -S go-tuner-git`).
 
 Use this install script:
 
-> $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/Pauloo27/tuner/master/install-debian.sh)"
+> $ wget -O - https://raw.githubusercontent.com/Pauloo27/tuner/master/install-debian.sh | bash  
+
 
 ## Compile
 


### PR DESCRIPTION
Curl just can't source, so 'go' can't compile tuner:
![image](https://user-images.githubusercontent.com/62912704/159997741-698a8a58-2be3-497a-9b5e-0eca82cc2e80.png)
